### PR TITLE
Feature/date input updates

### DIFF
--- a/src/app/admin-camp-listing/admin-camp-listing.component.html
+++ b/src/app/admin-camp-listing/admin-camp-listing.component.html
@@ -50,8 +50,8 @@
   </div>
   <div class="card-footer">
     <button routerLink="/adminHome" class="btn btn-primary" style="float: left" (click)="back()">
-      <fa-icon [icon]="backIcon"></fa-icon> Back
+      <fa-icon [icon]="backIcon"></fa-icon> Don't Save
     </button>
-    <button class="btn btn-primary" style="float: right" (click)="submitCamp()">Save Camp Changes</button>
+    <button class="btn btn-primary" style="float: right" (click)="submitCamp()">Save</button>
   </div>
 </div>

--- a/src/app/admin-reports/admin-route-undelivered-items/admin-route-undelivered-items.component.html
+++ b/src/app/admin-reports/admin-route-undelivered-items/admin-route-undelivered-items.component.html
@@ -47,8 +47,8 @@
   </div>
   <div class="card-footer">
     <button (click)="back()" style="float: left" class="btn btn-primary" type="button">
-      <fa-icon [icon]="backIcon"></fa-icon> Back
+      <fa-icon [icon]="backIcon"></fa-icon> Don't Save
     </button>
-    <button *ngIf="isAdmin" class="btn btn-primary" style="float: right" (click)="submitItems()">Save Item Changes</button>
+    <button *ngIf="isAdmin" class="btn btn-primary" style="float: right" (click)="submitItems()">Save</button>
   </div>
 </div>

--- a/src/app/client/client-edit-modal/client-edit-modal.component.html
+++ b/src/app/client/client-edit-modal/client-edit-modal.component.html
@@ -68,7 +68,7 @@
       <div class="form-group row">
         <label for="birth-date" class="col-6 col-form-label">Birth Date (Date must be MM/DD/YYYY): </label>
         <div class="col-6">
-          <input id="birth-date" type="text" class="form-control" placeholder="mm\/dd\/yyyy"
+          <input id="birth-date" type="date" class="form-control" placeholder="mm\/dd\/yyyy"
             formControlName="birth_date" style="float:right;" />
         </div>
       </div>

--- a/src/app/client/client-edit-modal/client-edit-modal.component.html
+++ b/src/app/client/client-edit-modal/client-edit-modal.component.html
@@ -257,7 +257,7 @@
     </form>
   </div>
   <div class="modal-footer">
-    <button type="button" class="btn btn-primary" style="float:right;" [disabled]="!clientForm.valid" (click)="submitClient(); c('');">Save Client</button>
-    <button type="button" class="btn btn-outline-primary" style="float:right;" (click)="c('Close click')">Close</button>
+    <button type="button" class="btn btn-outline-primary" style="float:right;" (click)="c('Close click')">Don't Save</button>
+    <button type="button" class="btn btn-primary" style="float:right;" [disabled]="!clientForm.valid" (click)="submitClient(); c('');">Save</button>
   </div>
 </ng-template>

--- a/src/app/client/client-edit-modal/client-edit-modal.component.ts
+++ b/src/app/client/client-edit-modal/client-edit-modal.component.ts
@@ -148,7 +148,7 @@ export class ClientEditModalComponent implements OnInit {
     
     let now: Date = new Date();
     if (updatedClient.birth_date.toString() === '') {
-      alert('Birthday not entered in mm/dd/yyyy format');
+      alert('Birthday not fully entered');
       return;
     }
     this.staticBirthday = this.clientForm.get('birth_date').value

--- a/src/app/client/client-edit-modal/client-edit-modal.component.ts
+++ b/src/app/client/client-edit-modal/client-edit-modal.component.ts
@@ -69,7 +69,7 @@ export class ClientEditModalComponent implements OnInit {
     else {
       this.clientForm.patchValue({ birth_date: formatDate(this.clientForm.get('birth_date').value, 'yyyy-MM-dd', 'en') })
     }
-      this.modalService.open(this.editModal, { size: 'lg', backdrop: 'static' });
+    this.modalService.open(this.editModal, { size: 'lg', backdrop: 'static' });
   }
 
   toggleEditMode() {

--- a/src/app/client/client-edit/client-edit.component.html
+++ b/src/app/client/client-edit/client-edit.component.html
@@ -99,7 +99,7 @@
           <label for="dbh" class="col-6 col-form-label"><span style="background-color: yellow;">Date Became Homeless
               (Date must be MM/DD/YYYY):</span> </label>
           <div class="col-6">
-            <input id="dbh" type="text" class="form-control" placeholder="mm/dd/yyyy"
+            <input id="dbh" type="date" class="form-control" placeholder="mm/dd/yyyy"
               formControlName="date_became_homeless" style="float:right;" />
           </div>
         </div>
@@ -170,7 +170,7 @@
         <div class="form-group row">
           <label for="dm" class="col-6 col-form-label">Date Moved (Date must be MM/DD/YYYY): </label>
           <div class="col-6">
-            <input id="dm" type="text" class="form-control" placeholder="mm/dd/yyyy" formControlName="date_moved"
+            <input id="dm" type="date" class="form-control" placeholder="mm/dd/yyyy" formControlName="date_moved"
               style="float:right;" />
           </div>
         </div>

--- a/src/app/client/client-edit/client-edit.component.html
+++ b/src/app/client/client-edit/client-edit.component.html
@@ -373,8 +373,8 @@
     </form>
   </div>
   <div class="card-footer text-right">
-    <button type="button" class="btn btn-outline-primary" style="float:left;" (click)="close()">Close</button>
+    <button type="button" class="btn btn-outline-primary" style="float:left;" (click)="close()">Don't Save</button>
     <button class="btn btn-primary" type="button" style="float:right;" [disabled]="!clientForm.valid"
-      (click)="submitClient()">Save Client</button>
+      (click)="submitClient()">Save</button>
   </div>
 </div>

--- a/src/app/client/client-edit/client-edit.component.ts
+++ b/src/app/client/client-edit/client-edit.component.ts
@@ -16,6 +16,7 @@ import { ClientHomelessHistory } from 'app/models/client-homeless-histories';
 export class ClientEditComponent implements OnInit {
   badDate = false;
   clientForm: UntypedFormGroup;
+  regExpDate = /^\d{1,2}\/\d{1,2}\/\d{4}$/
   theClient: Client;
   url: any;
   byteArray: any;
@@ -237,6 +238,14 @@ export class ClientEditComponent implements OnInit {
       }
       else if (birthday.getTime() < pastDate.getTime()) {
         alert('You cannot set a birth date this far back in the past');
+        return;
+      }
+    }
+
+    // validate that date became homeless is not unreasonable
+    if (this.clientForm.get('date_became_homeless').value !== "") {
+      if (!this.regExpDate.test(this.clientForm.get('date_became_homeless').value)) {
+        alert('Date Became Homeless must be entered in format mm/dd/yyyy');
         return;
       }
     }

--- a/src/app/client/client-edit/client-edit.component.ts
+++ b/src/app/client/client-edit/client-edit.component.ts
@@ -16,7 +16,7 @@ import { ClientHomelessHistory } from 'app/models/client-homeless-histories';
 export class ClientEditComponent implements OnInit {
   badDate = false;
   clientForm: UntypedFormGroup;
-  regExpDate = /^\d{1,2}\/\d{1,2}\/\d{4}$/
+  regExpDate = /^\d{4}-\d{1,2}-\d{1,2}$/
   theClient: Client;
   url: any;
   byteArray: any;
@@ -245,7 +245,7 @@ export class ClientEditComponent implements OnInit {
     // validate that date became homeless is not unreasonable
     if (this.clientForm.get('date_became_homeless').value !== "") {
       if (!this.regExpDate.test(this.clientForm.get('date_became_homeless').value)) {
-        alert('Date Became Homeless must be entered in format mm/dd/yyyy');
+        alert('Please finish filling out the entire "Date Became Homeless" field');
         return;
       }
     }
@@ -263,8 +263,6 @@ export class ClientEditComponent implements OnInit {
           return;
         }
 
-        // TODO need to update dwelling logic here like the modal if we choose not to
-        // change the DB; otherwise this can all stay the same (same w/ below area)
         const theHistory: ClientHomelessHistory = new ClientHomelessHistory();
         theHistory.client_id = insertedClient.id;
         theHistory.reason_for_homelessness = reason_for_homelessness;
@@ -321,8 +319,6 @@ export class ClientEditComponent implements OnInit {
             return;
           }
 
-        // TODO need to update dwelling logic here like the modal if we choose not to
-        // change the DB; otherwise this can all stay the same (same w/ above area)
           const theHistory: ClientHomelessHistory = new ClientHomelessHistory();
           theHistory.reason_for_homelessness = reason_for_homelessness;
           theHistory.date_became_homeless = new Date(Date.parse(this.clientForm.get('date_became_homeless').value));

--- a/src/app/client/client-edit/client-edit.component.ts
+++ b/src/app/client/client-edit/client-edit.component.ts
@@ -16,7 +16,6 @@ import { ClientHomelessHistory } from 'app/models/client-homeless-histories';
 export class ClientEditComponent implements OnInit {
   badDate = false;
   clientForm: UntypedFormGroup;
-  regExpDate = /^\d{4}-\d{1,2}-\d{1,2}$/
   theClient: Client;
   url: any;
   byteArray: any;
@@ -225,16 +224,9 @@ export class ClientEditComponent implements OnInit {
     }
     this.theClient.what_brought_to_des_moines = reason_for_des_moines;
 
-    console.log('date_became_homeless', this.clientForm.get('date_became_homeless').value);
-    console.log('date_moved', this.clientForm.get('date_moved').value);
-
     // validate that client birth date is not unreasonable
     if (this.theClient.birth_date) {
       console.log(new Date(this.clientForm.get('birth_date').value).toDateString());
-      if (!this.regExpDate.test(this.clientForm.get('birth_date').value)) {
-        alert('Please finish filling out the entire "Birthday" field');
-        return;
-      }
 
       let now: Date = new Date();
       let birthday: Date = new Date(this.theClient.birth_date);

--- a/src/app/client/client-edit/client-edit.component.ts
+++ b/src/app/client/client-edit/client-edit.component.ts
@@ -16,7 +16,6 @@ import { ClientHomelessHistory } from 'app/models/client-homeless-histories';
 export class ClientEditComponent implements OnInit {
   badDate = false;
   clientForm: UntypedFormGroup;
-  regExpDate = /^\d{1,2}\/\d{1,2}\/\d{4}$/
   theClient: Client;
   url: any;
   byteArray: any;
@@ -228,31 +227,16 @@ export class ClientEditComponent implements OnInit {
     // validate that client birth date is not unreasonable
     if (this.theClient.birth_date) {
       console.log(new Date(this.clientForm.get('birth_date').value).toDateString());
-      if (!this.regExpDate.test(formatDate(new Date(this.clientForm.get('birth_date').value), 'MM/dd/yyyy', this.locale))) {
-        alert('Birth date must be entered in format mm/dd/yyyy');
-        return;
-      }
 
       let now: Date = new Date();
       let birthday: Date = new Date(this.theClient.birth_date);
       let pastDate: Date = new Date(now.getFullYear() - 100, now.getMonth(), now.getDate());
-      if (!this.regExpDate.test(formatDate(birthday, 'MM/dd/yyyy', this.locale))) {
-
-      }
       if (birthday.getTime() > now.getTime()) {
         alert('You cannot select a birth date that is in the future');
         return;
       }
       else if (birthday.getTime() < pastDate.getTime()) {
         alert('You cannot set a birth date this far back in the past');
-        return;
-      }
-    }
-
-    // validate that date became homeless is not unreasonable
-    if (this.clientForm.get('date_became_homeless').value !== "") {
-      if (!this.regExpDate.test(this.clientForm.get('date_became_homeless').value)) {
-        alert('Date Became Homeless must be entered in format mm/dd/yyyy');
         return;
       }
     }
@@ -270,6 +254,8 @@ export class ClientEditComponent implements OnInit {
           return;
         }
 
+        // TODO need to update dwelling logic here like the modal if we choose not to
+        // change the DB; otherwise this can all stay the same (same w/ below area)
         const theHistory: ClientHomelessHistory = new ClientHomelessHistory();
         theHistory.client_id = insertedClient.id;
         theHistory.reason_for_homelessness = reason_for_homelessness;
@@ -326,6 +312,8 @@ export class ClientEditComponent implements OnInit {
             return;
           }
 
+        // TODO need to update dwelling logic here like the modal if we choose not to
+        // change the DB; otherwise this can all stay the same (same w/ above area)
           const theHistory: ClientHomelessHistory = new ClientHomelessHistory();
           theHistory.reason_for_homelessness = reason_for_homelessness;
           theHistory.date_became_homeless = new Date(Date.parse(this.clientForm.get('date_became_homeless').value));

--- a/src/app/client/client-edit/client-edit.component.ts
+++ b/src/app/client/client-edit/client-edit.component.ts
@@ -225,9 +225,16 @@ export class ClientEditComponent implements OnInit {
     }
     this.theClient.what_brought_to_des_moines = reason_for_des_moines;
 
+    console.log('date_became_homeless', this.clientForm.get('date_became_homeless').value);
+    console.log('date_moved', this.clientForm.get('date_moved').value);
+
     // validate that client birth date is not unreasonable
     if (this.theClient.birth_date) {
       console.log(new Date(this.clientForm.get('birth_date').value).toDateString());
+      if (!this.regExpDate.test(this.clientForm.get('birth_date').value)) {
+        alert('Please finish filling out the entire "Birthday" field');
+        return;
+      }
 
       let now: Date = new Date();
       let birthday: Date = new Date(this.theClient.birth_date);
@@ -238,14 +245,6 @@ export class ClientEditComponent implements OnInit {
       }
       else if (birthday.getTime() < pastDate.getTime()) {
         alert('You cannot set a birth date this far back in the past');
-        return;
-      }
-    }
-
-    // validate that date became homeless is not unreasonable
-    if (this.clientForm.get('date_became_homeless').value !== "") {
-      if (!this.regExpDate.test(this.clientForm.get('date_became_homeless').value)) {
-        alert('Please finish filling out the entire "Date Became Homeless" field');
         return;
       }
     }

--- a/src/app/client/servicing-client/servicing-client.component.html
+++ b/src/app/client/servicing-client/servicing-client.component.html
@@ -55,7 +55,7 @@
               <th>Serial #</th>
               <th>Date Given</th>
               <th>Action</th>
-              <th>Submit</th>
+              <th>Save</th>
             </tr>
           </thead>
           <tbody>
@@ -76,7 +76,7 @@
               <td>
                 <button type="button" (click)="submitHeaterStatus(heater.id, heaterStatus.value)"
                   class="btn btn-primary" *ngIf="currentStatus != 2">
-                  Submit
+                  Save
                 </button>
               </td>
             </tr>
@@ -91,7 +91,7 @@
                   <option *ngFor="let option of heaterStatuses" value="{{option.id}}">{{option.status_name}}</option>
                 </select></td>
               <td><button type="button" (click)="submitTankStatus(tank.id, tankStatus.value)"
-                  class="btn btn-primary">Submit</button></td>
+                  class="btn btn-primary">Save</button></td>
             </tr>
             <tr *ngFor="let hose of hoseInteractions">
               <td>Hose</td>
@@ -107,7 +107,7 @@
               </td>
               <td>
                 <button type="button" (click)="submitHoseStatus(hose.id, hoseStatus.value)"
-                  class="btn btn-primary">Submit</button>
+                  class="btn btn-primary">Save</button>
               </td>
             </tr>
           </tbody>

--- a/src/app/create-location-camp/create-location-camp.component.html
+++ b/src/app/create-location-camp/create-location-camp.component.html
@@ -46,8 +46,8 @@
     </div>
     <div class="card-footer">
       <div class="text-center">
-        <button type="button" class="btn btn-primary" style="float:right;" [disabled]="!locationCampForm.valid" (click)="submitLocationCamp()" >Submit Location Camp</button>
-        <button type="button" class="btn btn-primary" style="float:left;" (click)="back()">Back</button>
+        <button type="button" class="btn btn-primary" style="float:left;" (click)="back()">Don't Save</button>
+        <button type="button" class="btn btn-primary" style="float:right;" [disabled]="!locationCampForm.valid" (click)="submitLocationCamp()" >Save Location Camp</button>
       </div>
     </div>
   </div>

--- a/src/app/insert-modals/camp-notes/camp-notes.component.html
+++ b/src/app/insert-modals/camp-notes/camp-notes.component.html
@@ -31,17 +31,17 @@
   <div class="modal-footer">
     <button
       type="button"
-      class="btn btn-primary"
-      (click)="submitCampNote(); c('')"
-    >
-      Submit
-    </button>
-    <button
-      type="button"
       class="btn btn-outline-primary"
       (click)="c('Close click')"
     >
-      Close
+      Don't Save
+    </button>
+    <button
+      type="button"
+      class="btn btn-primary"
+      (click)="submitCampNote(); c('')"
+    >
+      Save
     </button>
   </div>
 </ng-template>

--- a/src/app/insert-modals/client-circle-of-friends/client-circle-of-friends.component.html
+++ b/src/app/insert-modals/client-circle-of-friends/client-circle-of-friends.component.html
@@ -30,7 +30,7 @@
       </div>
     </form>
     <div class="modal-footer">
-      <button type="button" class="btn btn-primary" (click)="submitFriend();c('')">Submit</button>
-      <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Close</button>
+      <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Don't Save</button>
+      <button type="button" class="btn btn-primary" (click)="submitFriend();c('')">Save</button>
     </div>
   </ng-template>

--- a/src/app/insert-modals/client-dislike/client-dislike.component.html
+++ b/src/app/insert-modals/client-dislike/client-dislike.component.html
@@ -15,7 +15,7 @@
     </div>
   </form>
   <div class="modal-footer">
-    <button type="button" class="btn btn-primary" (click)="submitDislike();c('')">Submit</button>
-    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Close</button>
+    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Don't Save</button>
+    <button type="button" class="btn btn-primary" (click)="submitDislike();c('')">Save</button>
   </div>
 </ng-template>

--- a/src/app/insert-modals/client-dwelling/client-dwelling.component.html
+++ b/src/app/insert-modals/client-dwelling/client-dwelling.component.html
@@ -9,7 +9,7 @@
           <div class="row">
             <div class="col-md-6">
               <label for="date-moved">Date Moved (Date must be MM/DD/YYYY)</label>
-              <input id="date-moved" type="text" class="form-control" placeholder="mm/dd/yyyy" [(ngModel)]="date_moved" style="float:left;"/>
+              <input id="date-moved" type="date" class="form-control" placeholder="mm/dd/yyyy" [(ngModel)]="date_moved" style="float:left;"/>
             </div>
             <div class="col-md-6">
               <label for="dwelling-location">Dwelling Location</label>

--- a/src/app/insert-modals/client-dwelling/client-dwelling.component.html
+++ b/src/app/insert-modals/client-dwelling/client-dwelling.component.html
@@ -9,7 +9,7 @@
           <div class="row">
             <div class="col-md-6">
               <label for="date-moved">Date Moved (Date must be MM/DD/YYYY)</label>
-              <input id="date-moved" type="date" class="form-control" placeholder="mm/dd/yyyy" [(ngModel)]="date_moved" style="float:left;"/>
+              <input id="date-moved" type="date" class="form-control" placeholder="mm/dd/yyyy" [(ngModel)]="date_moved" [ngModel]="date_moved | date:'yyyy-MM-dd'" style="float:left;"/>
             </div>
             <div class="col-md-6">
               <label for="dwelling-location">Dwelling Location</label>

--- a/src/app/insert-modals/client-dwelling/client-dwelling.component.html
+++ b/src/app/insert-modals/client-dwelling/client-dwelling.component.html
@@ -68,7 +68,7 @@
       </div>
     </form>
     <div class="modal-footer">
-      <button type="button" class="btn btn-primary" (click)="submitClientDwelling();c('')">Submit</button>
-      <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Close</button>
+      <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Don't Save</button>
+      <button type="button" class="btn btn-primary" (click)="submitClientDwelling();c('')">Save</button>
     </div>
   </ng-template>

--- a/src/app/insert-modals/client-dwelling/client-dwelling.component.ts
+++ b/src/app/insert-modals/client-dwelling/client-dwelling.component.ts
@@ -53,17 +53,18 @@ export class ClientDwellingComponent implements OnInit {
     const clientDwelling = new ClientDwelling();
     const clientId: number = JSON.parse(localStorage.getItem('selectedClient'));
     const routeInstanceId: number = this.isAdmin ? -1 : JSON.parse(localStorage.getItem('routeInstance'));
+
+    if (this.dwelling === '') {
+      alert('No dwelling entered');
+      return;
+    }
     
-    if (this.dwelling != null && !isNaN(clientId) && !isNaN(routeInstanceId)) {
-      // TODO might be able to remove all this new stuff if we update the DB instead
-      if (this.date_moved.toString() === '') {
-        alert('Date moved not entered in mm/dd/yyyy format');
+    if (this.dwelling !== '' && !isNaN(clientId) && !isNaN(routeInstanceId)) {
+      if (typeof this.date_moved === 'undefined') {
+        alert('Date moved not fully entered');
         return;
       }
-      // convert to local string format so html date input accounts for UTC adjustment before date conversion
-      let stringDateMoved = formatDate(this.date_moved, 'MM/dd/yyyy', 'en')
-      let dateMoved: Date = new Date(stringDateMoved);
-      clientDwelling.date_moved = new Date(dateMoved);
+      clientDwelling.date_moved = new Date(this.date_moved);
       clientDwelling.dwelling = (this.dwelling == 'Other') ? this.other_dwelling : this.dwelling;
       clientDwelling.notes = this.notes;
       clientDwelling.client_id = clientId;

--- a/src/app/insert-modals/client-dwelling/client-dwelling.component.ts
+++ b/src/app/insert-modals/client-dwelling/client-dwelling.component.ts
@@ -2,7 +2,6 @@ import { Component, ViewChild, Output, OnInit, ElementRef, EventEmitter } from '
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ClientService } from 'app/services/client.service';
 import { ClientDwelling } from 'app/models/client-dwelling';
-import { formatDate } from '@angular/common';
 
 @Component({
   selector: 'app-client-dwellings',
@@ -60,10 +59,6 @@ export class ClientDwellingComponent implements OnInit {
     }
     
     if (this.dwelling !== '' && !isNaN(clientId) && !isNaN(routeInstanceId)) {
-      if (typeof this.date_moved === 'undefined') {
-        alert('Date moved not fully entered');
-        return;
-      }
       clientDwelling.date_moved = new Date(this.date_moved);
       clientDwelling.dwelling = (this.dwelling == 'Other') ? this.other_dwelling : this.dwelling;
       clientDwelling.notes = this.notes;

--- a/src/app/insert-modals/client-dwelling/client-dwelling.component.ts
+++ b/src/app/insert-modals/client-dwelling/client-dwelling.component.ts
@@ -2,6 +2,7 @@ import { Component, ViewChild, Output, OnInit, ElementRef, EventEmitter } from '
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { ClientService } from 'app/services/client.service';
 import { ClientDwelling } from 'app/models/client-dwelling';
+import { formatDate } from '@angular/common';
 
 @Component({
   selector: 'app-client-dwellings',
@@ -54,7 +55,15 @@ export class ClientDwellingComponent implements OnInit {
     const routeInstanceId: number = this.isAdmin ? -1 : JSON.parse(localStorage.getItem('routeInstance'));
     
     if (this.dwelling != null && !isNaN(clientId) && !isNaN(routeInstanceId)) {
-      clientDwelling.date_moved = new Date(this.date_moved);
+      // TODO might be able to remove all this new stuff if we update the DB instead
+      if (this.date_moved.toString() === '') {
+        alert('Date moved not entered in mm/dd/yyyy format');
+        return;
+      }
+      // convert to local string format so html date input accounts for UTC adjustment before date conversion
+      let stringDateMoved = formatDate(this.date_moved, 'MM/dd/yyyy', 'en')
+      let dateMoved: Date = new Date(stringDateMoved);
+      clientDwelling.date_moved = new Date(dateMoved);
       clientDwelling.dwelling = (this.dwelling == 'Other') ? this.other_dwelling : this.dwelling;
       clientDwelling.notes = this.notes;
       clientDwelling.client_id = clientId;

--- a/src/app/insert-modals/client-homeless-history/client-homeless-history.component.html
+++ b/src/app/insert-modals/client-homeless-history/client-homeless-history.component.html
@@ -17,7 +17,7 @@
         <div class="row">
           <div class="col-md-6">
             <label for="date-became-homeless">Date Became Homeless (Date must be MM/DD/YYYY)</label>
-            <input id="date-became-homeless" type="text" class="form-control" placeholder="mm/dd/yyyy"
+            <input id="date-became-homeless" type="date" class="form-control" placeholder="mm/dd/yyyy"
               [(ngModel)]="date_became_homeless" style="float:left;" />
           </div>
           <div class="col-md-6">

--- a/src/app/insert-modals/client-homeless-history/client-homeless-history.component.html
+++ b/src/app/insert-modals/client-homeless-history/client-homeless-history.component.html
@@ -18,7 +18,7 @@
           <div class="col-md-6">
             <label for="date-became-homeless">Date Became Homeless (Date must be MM/DD/YYYY)</label>
             <input id="date-became-homeless" type="date" class="form-control" placeholder="mm/dd/yyyy"
-              [(ngModel)]="date_became_homeless" style="float:left;" />
+              [(ngModel)]="date_became_homeless" [ngModel]="date_became_homeless | date:'yyyy-MM-dd'" style="float:left;" />
           </div>
           <div class="col-md-6">
             <label for="homeless-reason">Reason for Homelessness</label>

--- a/src/app/insert-modals/client-homeless-history/client-homeless-history.component.html
+++ b/src/app/insert-modals/client-homeless-history/client-homeless-history.component.html
@@ -49,7 +49,7 @@
     </div>
   </form>
   <div class="modal-footer">
-    <button type="button" class="btn btn-primary" (click)="submitClientHomelessHistory();c('')">Submit</button>
-    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Close</button>
+    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Don't Save</button>
+    <button type="button" class="btn btn-primary" (click)="submitClientHomelessHistory();c('')">Save</button>
   </div>
 </ng-template>

--- a/src/app/insert-modals/client-homeless-history/client-homeless-history.component.ts
+++ b/src/app/insert-modals/client-homeless-history/client-homeless-history.component.ts
@@ -32,7 +32,6 @@ export class ClientHomelessHistoryComponent {
     this.first_time_homeless = false;
     this.homeless_reason = '';
     this.notes = '';
-    this.date_became_homeless = null;
   }
 
   onChange(field_name: string, value: string) {
@@ -54,6 +53,10 @@ export class ClientHomelessHistoryComponent {
     const routeInstanceId: number = this.isAdmin ? -1 : JSON.parse(localStorage.getItem('routeInstance'));
     
     if (!isNaN(clientId) && !isNaN(routeInstanceId)) {
+      if (typeof this.date_became_homeless === 'undefined') {
+        alert('Date became homeless not fully entered');
+        return;
+      }
       clientHistory.first_time_homeless = this.first_time_homeless;
       clientHistory.date_became_homeless = new Date(this.date_became_homeless);
       clientHistory.reason_for_homelessness = (this.homeless_reason == 'Other') ? this.other_homeless_reason : this.homeless_reason;

--- a/src/app/insert-modals/client-homeless-history/client-homeless-history.component.ts
+++ b/src/app/insert-modals/client-homeless-history/client-homeless-history.component.ts
@@ -53,10 +53,6 @@ export class ClientHomelessHistoryComponent {
     const routeInstanceId: number = this.isAdmin ? -1 : JSON.parse(localStorage.getItem('routeInstance'));
     
     if (!isNaN(clientId) && !isNaN(routeInstanceId)) {
-      if (typeof this.date_became_homeless === 'undefined') {
-        alert('Date became homeless not fully entered');
-        return;
-      }
       clientHistory.first_time_homeless = this.first_time_homeless;
       clientHistory.date_became_homeless = new Date(this.date_became_homeless);
       clientHistory.reason_for_homelessness = (this.homeless_reason == 'Other') ? this.other_homeless_reason : this.homeless_reason;

--- a/src/app/insert-modals/client-like/client-like.component.html
+++ b/src/app/insert-modals/client-like/client-like.component.html
@@ -15,7 +15,7 @@
     </div>
   </form>
   <div class="modal-footer">
-    <button type="button" class="btn btn-primary" (click)="submitLike();c('')">Submit</button>
-    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Close</button>
+    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Don't Save</button>
+    <button type="button" class="btn btn-primary" (click)="submitLike();c('')">Save</button>
   </div>
 </ng-template>

--- a/src/app/insert-modals/date-selector/date-selector.component.html
+++ b/src/app/insert-modals/date-selector/date-selector.component.html
@@ -13,6 +13,6 @@
     </div>
 </form>
 <div class="modal-footer">
-    <button type="button" class="btn btn-primary" (click)="submitDate()">Submit</button>
-    <button type="button" class="btn btn-outline-primary" (click)="activeModal.close()">Close</button>
+    <button type="button" class="btn btn-outline-primary" (click)="activeModal.close()">Don't Save</button>
+    <button type="button" class="btn btn-primary" (click)="submitDate()">Save</button>
 </div>

--- a/src/app/insert-modals/goals-steps/goals-steps.component.html
+++ b/src/app/insert-modals/goals-steps/goals-steps.component.html
@@ -15,7 +15,7 @@
     </div>
   </form>
   <div class="modal-footer">
-    <button type="button" class="btn btn-primary" (click)="submitGoal();c('')">Submit</button>
-    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Close</button>
+    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Don't Save</button>
+    <button type="button" class="btn btn-primary" (click)="submitGoal();c('')">Save</button>
   </div>
 </ng-template>

--- a/src/app/insert-modals/health-concern/health-concern.component.html
+++ b/src/app/insert-modals/health-concern/health-concern.component.html
@@ -15,7 +15,7 @@
     </div>
   </form>
   <div class="modal-footer">
-    <button type="button" class="btn btn-primary" (click)="submitHealthConcern();c('')">Submit</button>
-    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Close</button>
+    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Don't Save</button>
+    <button type="button" class="btn btn-primary" (click)="submitHealthConcern();c('')">Save</button>
   </div>
 </ng-template>

--- a/src/app/insert-modals/income/income.component.html
+++ b/src/app/insert-modals/income/income.component.html
@@ -30,7 +30,7 @@
         </div>
     </form>
     <div class="modal-footer">
-        <button type="button" class="btn btn-primary" (click)="submitIncome();c('')">Submit</button>
-        <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Close</button>
+        <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Don't Save</button>
+        <button type="button" class="btn btn-primary" (click)="submitIncome();c('')">Save</button>
     </div>
 </ng-template>

--- a/src/app/insert-modals/next-of-kin/next-of-kin.component.html
+++ b/src/app/insert-modals/next-of-kin/next-of-kin.component.html
@@ -40,7 +40,7 @@
       </div>
     </form>
     <div class="modal-footer">
-      <button type="button" class="btn btn-primary" (click)="submitNextOfKin();c('')">Submit</button>
-      <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Close</button>
+      <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Don't Save</button>
+      <button type="button" class="btn btn-primary" (click)="submitNextOfKin();c('')">Save</button>
     </div>
   </ng-template>

--- a/src/app/insert-modals/notes/notes.component.html
+++ b/src/app/insert-modals/notes/notes.component.html
@@ -31,7 +31,7 @@
     </div>
   </form>
   <div class="modal-footer">
-    <button type="button" class="btn btn-primary" (click)="submitNote();c('')">Submit</button>
-    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Close</button>
+    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Don't Save</button>
+    <button type="button" class="btn btn-primary" (click)="submitNote();c('')">Save</button>
   </div>
 </ng-template>

--- a/src/app/insert-modals/pets/pets.component.html
+++ b/src/app/insert-modals/pets/pets.component.html
@@ -41,7 +41,7 @@
     </div>
   </form>
   <div class="modal-footer">
-    <button type="button" class="btn btn-primary" (click)="submitPet();c('')">Submit</button>
-    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Close</button>
+    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Don't Save</button>
+    <button type="button" class="btn btn-primary" (click)="submitPet();c('')">Save</button>
   </div>
 </ng-template>

--- a/src/app/insert-modals/prayer-requests-and-needs/prayer-requests-and-needs.component.html
+++ b/src/app/insert-modals/prayer-requests-and-needs/prayer-requests-and-needs.component.html
@@ -15,7 +15,7 @@
     </div>
   </form>
   <div class="modal-footer">
-    <button type="button" class="btn btn-primary" (click)="submitPrayerRequestNeed();c('')">Submit</button>
-    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Close</button>
+    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Don't Save</button>
+    <button type="button" class="btn btn-primary" (click)="submitPrayerRequestNeed();c('')">Save</button>
   </div>
 </ng-template>

--- a/src/app/insert-modals/referrals-resources/referrals-resources.component.html
+++ b/src/app/insert-modals/referrals-resources/referrals-resources.component.html
@@ -57,11 +57,11 @@
     </div>
   </form>
   <div class="modal-footer">
-    <button type="button" class="btn btn-primary" (click)="submitReferralsResources(); c('')">
-      Submit
-    </button>
     <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">
-      Close
+      Don't Save
+    </button>
+    <button type="button" class="btn btn-primary" (click)="submitReferralsResources(); c('')">
+      Save
     </button>
   </div>
 </ng-template>

--- a/src/app/insert-modals/requested-item/requested-item.component.html
+++ b/src/app/insert-modals/requested-item/requested-item.component.html
@@ -47,11 +47,11 @@
     </div>
   </form>
   <div class="modal-footer">
-    <button type="button" class="btn btn-primary" (click)="submitItem(); c('')">
-      Submit
-    </button>
     <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">
-      Close
+      Don't Save
+    </button>
+    <button type="button" class="btn btn-primary" (click)="submitItem(); c('')">
+      Save
     </button>
   </div>
 </ng-template>

--- a/src/app/insert-modals/tents/tent.component.html
+++ b/src/app/insert-modals/tents/tent.component.html
@@ -47,8 +47,8 @@
       </div>
     </form>
     <div class="modal-footer">
-      <button type="button" class="btn btn-primary" (click)="submitTent();c('')">Submit</button>
-      <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Close</button>
+      <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Don't Save</button>
+      <button type="button" class="btn btn-primary" (click)="submitTent();c('')">Save</button>
     </div>
   </ng-template>
   

--- a/src/app/location-camp/camp-edit-modal/camp-edit-modal.component.html
+++ b/src/app/location-camp/camp-edit-modal/camp-edit-modal.component.html
@@ -207,18 +207,18 @@
   <div class="modal-footer">
     <button
       type="button"
+      class="btn btn-outline-primary"
+      (click)="c('Close click')"
+    >
+      Don't Save
+    </button>
+    <button
+      type="button"
       [disabled]="!campForm.valid"
       (click)="submitCamp(); c('')"
       class="btn btn-primary"
     >
-      Submit Camp
-    </button>
-    <button
-      type="button"
-      class="btn btn-outline-primary"
-      (click)="c('Close click')"
-    >
-      Close
+      Save
     </button>
   </div>
 </ng-template>

--- a/src/app/routes/route-edit-modal/route-edit-modal.component.html
+++ b/src/app/routes/route-edit-modal/route-edit-modal.component.html
@@ -42,7 +42,7 @@
     </form>
   </div>
   <div class="modal-footer">
-    <button type="button" [disabled]="!routeForm.valid" (click)="submitRoute(); c('');" class="btn btn-primary">Submit Route</button>
-    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Close</button>
+    <button type="button" class="btn btn-outline-primary" (click)="c('Close click')">Don't Save</button>
+    <button type="button" [disabled]="!routeForm.valid" (click)="submitRoute(); c('');" class="btn btn-primary">Save</button>
   </div>
 </ng-template>


### PR DESCRIPTION
@wilsont3 Just a heads up that the date logic is deliberately different in client-edit-modal.component.ts. It's the only place in the client UI where a user can submit a modal with a date in it, and then go back and re-open that modal without a page refresh. This caused issues because the transient saving of the date field at the page level behaves differently before the HTML date is stripped of its UTC adjustment when it hits the DB. To the user, it looked like the pre-refresh date was saving one day earlier, even though it was actually saving 6 hours before midnight of the date they inputted, which is then rectified when it's saved as a date on the back end vs. datetime. This is the thing we avoided elsewhere by changing the other fields to date instead of datetime, but it's unavoidable here.

Otherwise, lots of validation and regex was pulled out because HTML dates will just send back nothing if they're not fully filled out, so if the field isn't required, there's nothing to validate if it's not a fully-formed date.

Also snuck in all the Save/Don't Save logic here so I could knock two things out while we waited on Megan's response to the date saving issue she mentioned in the third ticket.